### PR TITLE
Reshefs/s1065/support aws assume role

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,8 +12,8 @@ FROM base AS builder
 # Install the package
 RUN go install -v ./...
 
-#  ubuntu 20.04
-FROM ubuntu:focal-20210416 AS plugin
+#  ubuntu ignite 18.04
+FROM weaveworks/ignite-ubuntu AS plugin
 
 WORKDIR /blink-core
 COPY --from=builder /go/bin/blink-core .
@@ -85,6 +85,9 @@ RUN apt-get update && \
     apt-get install vault && \
     rm -rf /var/lib/apt/lists/* && \
     setcap cap_ipc_lock= /usr/bin/vault
+
+# Prerequisits for ignite
+RUN apt-get update && apt-get install -y systemd libpam-systemd
 
 # Expose the gRPC port.
 EXPOSE 1337

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -12,8 +12,8 @@ FROM base AS builder
 # Install the package
 RUN go install -v ./...
 
-#  ubuntu ignite 18.04
-FROM weaveworks/ignite-ubuntu AS plugin
+#  ubuntu 20.04
+FROM ubuntu:focal-20210416 AS plugin
 
 WORKDIR /blink-core
 COPY --from=builder /go/bin/blink-core .
@@ -85,9 +85,6 @@ RUN apt-get update && \
     apt-get install vault && \
     rm -rf /var/lib/apt/lists/* && \
     setcap cap_ipc_lock= /usr/bin/vault
-
-# Prerequisits for ignite
-RUN apt-get update && apt-get install -y systemd libpam-systemd
 
 # Expose the gRPC port.
 EXPOSE 1337

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/blinkops/blink-core
 go 1.16
 
 require (
+	github.com/aws/aws-sdk-go v1.25.37
 	github.com/blinkops/blink-sdk v1.0.51
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/pkg/errors v0.8.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.5.1
 	golang.org/x/net v0.0.0-20201110031124-69a78807bb2b // indirect
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/mail.v2 v2.3.1

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,7 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/armon/go-metrics v0.3.0/go.mod h1:zXjbSimjXTd7vOpY8B0/2LpvNvDoXBuplAD+gJD3GYs=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/aws/aws-sdk-go v1.25.37 h1:gBtB/F3dophWpsUQKN/Kni+JzYEH2mGHF4hWNtfED1w=
 github.com/aws/aws-sdk-go v1.25.37/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
@@ -75,6 +76,7 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hashicorp/vault/api v1.1.0/go.mod h1:R3Umvhlxi2TN7Ex2hzOowyeNb+SfbVWI973N+ctaFMk=
 github.com/hashicorp/vault/sdk v0.1.14-0.20200519221838-e0cfd64bc267/go.mod h1:WX57W2PwkrOPQ6rVQk+dy5/htHIaB4aBM70EwKThu10=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=

--- a/implementation/aws_utils.go
+++ b/implementation/aws_utils.go
@@ -3,16 +3,22 @@ package implementation
 import (
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"os"
 	"strconv"
 	"math/rand"
 )
 
-func determineConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
+
+// access keys have to be both set
+// role arn can be supplied alone if it's irsa
+// role arn and external id have to be supplied together for traditional assume role
+func detectConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
-		if awsCredentials[roleArn] == "" || awsCredentials[externalID] == "" {
+		if awsCredentials[roleArn] == "" {
 			return "", "", ""
 		} else {
 			return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
@@ -36,21 +42,49 @@ func convertInterfaceMapToStringMap(m map[string]interface{}) map[string]string 
 	return mapString
 }
 
-func assumeRole(role, externalID, region string) (string, string, string, error) {
+func assumeRole(role, externalID, region string) (access, secret, sessionToken string, err error) {
 	sess, _ := session.NewSession(&aws.Config{
 		Region: aws.String(region),
 	})
+
 	svc := sts.New(sess)
-
 	sessionName := strconv.Itoa(rand.Int())
-	result, err := svc.AssumeRole(&sts.AssumeRoleInput{
-		RoleArn:         &role,
-		RoleSessionName: &sessionName,
-		ExternalId: &externalID,
-	})
 
-	if err != nil {
-		return "", "", "", fmt.Errorf("unable to assume role with error: %w", err)
+	// irsa does not work with externalID, only the "traditional" assume role does
+	if externalID == "" {
+		tokenFile, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
+		if !ok {
+			return access, secret, sessionToken, fmt.Errorf("token file for irsa not found. make sure pod is configured correctly and that your service account is created and properly annotated")
+		}
+
+		log.Debug("assuming role with web identity")
+		data, err := ioutil.ReadFile(tokenFile)
+		if err != nil {
+			return access, secret, sessionToken, fmt.Errorf("unable to open web identity token file with error: %w", err)
+		}
+
+		fmt.Println("Contents of file:", string(data))
+		result, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+			DurationSeconds:  aws.Int64(3600),
+			RoleArn:          aws.String(role),
+			RoleSessionName:  aws.String(sessionName),
+			WebIdentityToken: aws.String(string(data)),
+		})
+		if err != nil {
+			return access, secret, sessionToken, fmt.Errorf("unable to assume web identity role with error: %w", err)
+		}
+		access, secret, sessionToken = *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken
+	} else {
+		log.Debug("assuming role with trusted entity")
+		result, err := svc.AssumeRole(&sts.AssumeRoleInput{
+			RoleArn:         &role,
+			RoleSessionName: &sessionName,
+			ExternalId:      &externalID,
+		})
+		if err != nil {
+			return access, secret, sessionToken, fmt.Errorf("unable to assume trusted identity role with error: %w", err)
+		}
+		access, secret, sessionToken = *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken
 	}
-	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, nil
+	return access, secret, sessionToken, nil
 }

--- a/implementation/aws_utils.go
+++ b/implementation/aws_utils.go
@@ -1,0 +1,56 @@
+package implementation
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"strconv"
+	"math/rand"
+)
+
+func determineConnectionType(awsCredentials map[string]string) (credsType, key, value string) {
+	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
+		if awsCredentials[roleArn] == "" || awsCredentials[externalID] == "" {
+			return "", "", ""
+		} else {
+			return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
+		}
+	}
+	return "userBased", awsCredentials[awsAccessKeyId], awsCredentials[awsSecretAccessKey]
+}
+
+func convertInterfaceMapToStringMap(m map[string]interface{}) map[string]string {
+	mapString := make(map[string]string)
+	for key, value := range m {
+		var strValue string
+		strKey := fmt.Sprintf("%v", key)
+		if value == nil {
+			strValue = ""
+		} else {
+			strValue = fmt.Sprintf("%v", value)
+		}
+		mapString[strKey] = strValue
+	}
+	return mapString
+}
+
+func assumeRole(role, externalID, region string) (string, string, string, error) {
+	sess, _ := session.NewSession(&aws.Config{
+		Region: aws.String(region),
+	})
+	svc := sts.New(sess)
+
+	sessionName := strconv.Itoa(rand.Int())
+	result, err := svc.AssumeRole(&sts.AssumeRoleInput{
+		RoleArn:         &role,
+		RoleSessionName: &sessionName,
+		ExternalId: &externalID,
+	})
+
+	if err != nil {
+		return "", "", "", fmt.Errorf("unable to assume role with error: %w", err)
+	}
+	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, nil
+}

--- a/implementation/aws_utils.go
+++ b/implementation/aws_utils.go
@@ -7,9 +7,9 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	log "github.com/sirupsen/logrus"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strconv"
-	"math/rand"
 )
 
 
@@ -42,6 +42,51 @@ func convertInterfaceMapToStringMap(m map[string]interface{}) map[string]string 
 	return mapString
 }
 
+func readFile(path string) (string, error) {
+	data, err := ioutil.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func assumeRoleWithWebIdentity(svc *sts.STS, role, sessionName string) (string, string, string, error) {
+	log.Debug("assuming role with web identity")
+	tokenFile, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
+	if !ok {
+		return "", "", "", fmt.Errorf("token file for irsa not found. make sure your pod is configured correctly and that your service account is created and annotated properly")
+	}
+
+	data, err := readFile(tokenFile)
+	if err != nil {
+		return "", "", "", fmt.Errorf("unable to open web identity token file with error: %w", err)
+	}
+
+	result, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
+		DurationSeconds:  aws.Int64(3600),
+		RoleArn:          aws.String(role),
+		RoleSessionName:  aws.String(sessionName),
+		WebIdentityToken: aws.String(string(data)),
+	})
+	if err != nil {
+		return "", "", "", err
+	}
+	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, err
+}
+
+func assumeRoleWithTrustedIdentity(svc *sts.STS, role, externalID, sessionName string) (string, string, string, error) {
+	log.Debug("assuming role with trusted entity")
+	result, err := svc.AssumeRole(&sts.AssumeRoleInput{
+		RoleArn:         &role,
+		RoleSessionName: &sessionName,
+		ExternalId:      &externalID,
+	})
+	if err != nil {
+		return "", "", "", err
+	}
+	return *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken, err
+}
+
 func assumeRole(role, externalID, region string) (access, secret, sessionToken string, err error) {
 	sess, _ := session.NewSession(&aws.Config{
 		Region: aws.String(region),
@@ -52,38 +97,7 @@ func assumeRole(role, externalID, region string) (access, secret, sessionToken s
 
 	// irsa does not work with externalID, only the "traditional" assume role does
 	if externalID == "" {
-		tokenFile, ok := os.LookupEnv("AWS_WEB_IDENTITY_TOKEN_FILE")
-		if !ok {
-			return access, secret, sessionToken, fmt.Errorf("token file for irsa not found. make sure pod is configured correctly and that your service account is created and properly annotated")
-		}
-
-		log.Debug("assuming role with web identity")
-		data, err := ioutil.ReadFile(tokenFile)
-		if err != nil {
-			return access, secret, sessionToken, fmt.Errorf("unable to open web identity token file with error: %w", err)
-		}
-
-		result, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
-			DurationSeconds:  aws.Int64(3600),
-			RoleArn:          aws.String(role),
-			RoleSessionName:  aws.String(sessionName),
-			WebIdentityToken: aws.String(string(data)),
-		})
-		if err != nil {
-			return access, secret, sessionToken, fmt.Errorf("unable to assume web identity role with error: %w", err)
-		}
-		access, secret, sessionToken = *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken
-	} else {
-		log.Debug("assuming role with trusted entity")
-		result, err := svc.AssumeRole(&sts.AssumeRoleInput{
-			RoleArn:         &role,
-			RoleSessionName: &sessionName,
-			ExternalId:      &externalID,
-		})
-		if err != nil {
-			return access, secret, sessionToken, fmt.Errorf("unable to assume trusted identity role with error: %w", err)
-		}
-		access, secret, sessionToken = *result.Credentials.AccessKeyId, *result.Credentials.SecretAccessKey, *result.Credentials.SessionToken
+		return assumeRoleWithWebIdentity(svc, role, sessionName)
 	}
-	return access, secret, sessionToken, nil
+	return assumeRoleWithTrustedIdentity(svc, role, externalID, sessionName)
 }

--- a/implementation/aws_utils.go
+++ b/implementation/aws_utils.go
@@ -63,7 +63,6 @@ func assumeRole(role, externalID, region string) (access, secret, sessionToken s
 			return access, secret, sessionToken, fmt.Errorf("unable to open web identity token file with error: %w", err)
 		}
 
-		fmt.Println("Contents of file:", string(data))
 		result, err := svc.AssumeRoleWithWebIdentity(&sts.AssumeRoleWithWebIdentityInput{
 			DurationSeconds:  aws.Int64(3600),
 			RoleArn:          aws.String(role),

--- a/implementation/aws_utils.go
+++ b/implementation/aws_utils.go
@@ -1,9 +1,9 @@
 package implementation
 
 import (
-	"math/rand"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"strconv"
 
@@ -20,9 +20,8 @@ func detectConnectionType(awsCredentials map[string]string) (credsType, key, val
 	if awsCredentials[awsAccessKeyId] == "" || awsCredentials[awsSecretAccessKey] == "" {
 		if awsCredentials[roleArn] == "" {
 			return "", "", ""
-		} else {
-			return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
 		}
+		return "roleBased", awsCredentials[roleArn], awsCredentials[externalID]
 	}
 	return "userBased", awsCredentials[awsAccessKeyId], awsCredentials[awsSecretAccessKey]
 }

--- a/implementation/aws_utils_test.go
+++ b/implementation/aws_utils_test.go
@@ -1,0 +1,132 @@
+package implementation
+
+import (
+	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/aws-sdk-go/service/sts/stsiface"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+type STSMockClient struct {
+	stsiface.STSAPI
+}
+
+func (s *STSMockClient) AssumeRole(input *sts.AssumeRoleInput) (*sts.AssumeRoleOutput, error) {
+	if *input.ExternalId == "eligezer" {
+		return &sts.AssumeRoleOutput{}, fmt.Errorf("invalid external ID")
+	}
+	return &sts.AssumeRoleOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId: aws.String("ASDASKDSDASDAS"),
+			SecretAccessKey: aws.String("SADASDQWDDASAS"),
+			SessionToken: aws.String("ASJDHASKJDAS"),
+		},
+	}, nil
+}
+
+func (s *STSMockClient) AssumeRoleWithWebIdentity(input *sts.AssumeRoleWithWebIdentityInput) (*sts.AssumeRoleWithWebIdentityOutput, error) {
+	if *input.RoleArn == "arn:aws:iam::12345678910:role/eligezer" {
+		return &sts.AssumeRoleWithWebIdentityOutput{}, fmt.Errorf("invalid role ARN")
+	}
+	return &sts.AssumeRoleWithWebIdentityOutput{
+		Credentials: &sts.Credentials{
+			AccessKeyId: aws.String("ASDASKDSDASDAS"),
+			SecretAccessKey: aws.String("SADASDQWDDASAS"),
+			SessionToken: aws.String("ASJDHASKJDAS"),
+		},
+	}, nil
+}
+
+
+func TestAssumeRole(t *testing.T) {
+	type args struct {
+		role string
+		externalID string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		wantErr        string
+	}{
+		{
+			name:           "successful trused identity assume role",
+			args:           args{role: "arn:aws:iam::12345678910:role/good-role", externalID: "waaaa"},
+			wantErr:        "",
+		},
+		{
+			name:           "unsuccessful trused identity assume role",
+			args:           args{role: "arn:aws:iam::630441286508:role/bad-role", externalID: "eligezer"},
+			wantErr:       "invalid external ID",
+		},
+		{
+			name:           "successful web identity assume role",
+			args:           args{role: "arn:aws:iam::630441286508:role/good-role", externalID: ""},
+			wantErr:        "",
+		},
+		{
+			name:           "unsuccessful web identity assume role",
+			args:           args{role: "arn:aws:iam::12345678910:role/eligezer", externalID: ""},
+			wantErr:        "invalid role ARN",
+		},
+	}
+
+	// this part mimics the service account annotation on plugin pods
+	file := "/tmp/lewl123"
+	err := os.WriteFile(file, []byte(""), 0644)
+	defer os.Remove(file)
+	if err != nil {
+		t.Error("unable to create temporary file")
+	}
+	os.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", file)
+
+	// mocking the sts client
+	client := &STSMockClient{}
+	for _, tt := range tests {
+		t.Run("test assumeRole(): "+tt.name, func(t *testing.T) {
+			_, _, _, err := assumeRole(client, tt.args.role, tt.args.externalID)
+			if tt.wantErr != "" {
+				require.NotNil(t, err, tt.name)
+				assert.Contains(t, err.Error(), tt.wantErr, tt.name)
+			} else {
+				require.Nil(t, err, tt.name)
+			}
+		})
+	}
+}
+
+func TestDetectConnectionType(t *testing.T) {
+	type args struct {
+		awsCreds map[string]string
+	}
+	tests := []struct {
+		name           string
+		args           args
+		credsType      string
+	}{
+		{
+			name:           "user based credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "ASDHASDSDHADHASD", awsSecretAccessKey: "ASDSADASDASAS", roleArn: "", externalID: ""}},
+			credsType:      "userBased",
+		},
+		{
+			name:           "role based credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "", awsSecretAccessKey: "", roleArn: "arn:aws:iam::12345678910:role/test", externalID: "eligezer"}},
+			credsType:      "roleBased",
+		},
+		{
+			name:           "bad credentials",
+			args:           args{awsCreds: map[string]string{awsAccessKeyId: "", awsSecretAccessKey: "", roleArn: "", externalID: ""}},
+			credsType:      "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run("test ActionExist(): "+tt.name, func(t *testing.T) {
+			result, _, _ := detectConnectionType(tt.args.awsCreds)
+			assert.Equal(t, tt.credsType, result)
+		})
+	}
+}

--- a/implementation/cli.go
+++ b/implementation/cli.go
@@ -67,7 +67,6 @@ func executeCoreAWSAction(ctx *plugin.ActionContext, request *plugin.ExecuteActi
 	}
 
 	environment = append(environment, fmt.Sprintf("%s=%v", regionEnvironmentVariable, region))
-
 	output, err := common.ExecuteCommand(request, environment, "/bin/bash", "-c", command)
 	if err != nil {
 		return common.GetCommandFailureResponse(output, err)

--- a/implementation/cli.go
+++ b/implementation/cli.go
@@ -3,6 +3,9 @@ package implementation
 import (
 	"errors"
 	"fmt"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/sts"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -52,7 +55,12 @@ func executeCoreAWSAction(ctx *plugin.ActionContext, request *plugin.ExecuteActi
 	sessionType, k, v := detectConnectionType(m)
 	switch sessionType {
 	case "roleBased":
-		m[awsAccessKeyId], m[awsSecretAccessKey], m[awsSessionToken], err = assumeRole(k, v, region)
+		sess, _ := session.NewSession(&aws.Config{
+			Region: aws.String(region),
+		})
+
+		svc := sts.New(sess)
+		m[awsAccessKeyId], m[awsSecretAccessKey], m[awsSessionToken], err = assumeRole(svc, k, v)
 		if err != nil {
 			return nil, fmt.Errorf("unable to assume role with error: %w", err)
 		}

--- a/implementation/cli.go
+++ b/implementation/cli.go
@@ -49,7 +49,7 @@ func executeCoreAWSAction(ctx *plugin.ActionContext, request *plugin.ExecuteActi
 	var environment environmentVariables
 
 	m := convertInterfaceMapToStringMap(credentials)
-	sessionType, k, v := determineConnectionType(m)
+	sessionType, k, v := detectConnectionType(m)
 	switch sessionType {
 	case "roleBased":
 		m[awsAccessKeyId], m[awsSecretAccessKey], m[awsSessionToken], err = assumeRole(k, v, region)

--- a/implementation/cli.go
+++ b/implementation/cli.go
@@ -23,6 +23,11 @@ const (
 	regionEnvironmentVariable = "AWS_DEFAULT_REGION"
 	vaultAddress              = "VAULT_ADDR"
 	vaultToken                = "VAULT_TOKEN"
+	awsAccessKeyId            = "aws_access_key_id"
+	awsSecretAccessKey        = "aws_secret_access_key"
+	awsSessionToken           = "aws_session_token"
+	roleArn                   = "role_arn"
+	externalID                = "external_id"
 )
 
 func executeCoreAWSAction(ctx *plugin.ActionContext, request *plugin.ExecuteActionRequest) ([]byte, error) {
@@ -42,7 +47,22 @@ func executeCoreAWSAction(ctx *plugin.ActionContext, request *plugin.ExecuteActi
 	}
 
 	var environment environmentVariables
-	for key, value := range credentials {
+
+	m := convertInterfaceMapToStringMap(credentials)
+	sessionType, k, v := determineConnectionType(m)
+	switch sessionType {
+	case "roleBased":
+		m[awsAccessKeyId], m[awsSecretAccessKey], m[awsSessionToken], err = assumeRole(k, v, region)
+		if err != nil {
+			return nil, fmt.Errorf("unable to assume role with error: %w", err)
+		}
+	case "userBased":
+		m[awsSessionToken] = ""
+	default:
+		return nil, fmt.Errorf("invalid credentials: make sure access+secret key are supplied OR role_arn+external_id")
+	}
+
+	for key, value := range m {
 		environment = append(environment, fmt.Sprintf("%s=%v", strings.ToUpper(key), value))
 	}
 


### PR DESCRIPTION
This commit adds support for assuming role both as Trusted Identity (user creates a role and allows our role to assume it), and Web Identity (user creates a role and assumes it from his POD using OIDC. no reference to our account at all).