### PR TITLE
Ofir/b1092 user and group

### DIFF
--- a/implementation/execution/private_execution.go
+++ b/implementation/execution/private_execution.go
@@ -63,7 +63,10 @@ func (p *PrivateExecutionEnvironment) GetExecutorGid() uint32 {
 }
 
 func (p *PrivateExecutionEnvironment) CreateDirectory(path string) error {
-	_, err := common.ExecuteCommand(p, nil, nil, "/bin/mkdir", "-p", path)
+	output, err := common.ExecuteCommand(p, nil, nil, "/bin/mkdir", "-p", path)
+	if err != nil {
+		log.Debugf("failed to create directory at: %v with output: %v and error: %v", path, string(output), err)
+	}
 	return err
 }
 

--- a/implementation/execution/private_execution.go
+++ b/implementation/execution/private_execution.go
@@ -210,20 +210,23 @@ func (ctrl *Controller) EnsureNameRootSet(pee *PrivateExecutionEnvironment) {
 	if pee.NameRoot != "" {
 		return
 	}
+
 	root := pee.SessionId[:6]
+	if !ctrl.nameInUse(root) {
+		pee.NameRoot = root
+		return
+	}
 
 	// Handle possible name collision
 	counter := 1
 	for {
-		candidate := root
-		if ctrl.nameInUse(candidate) {
-			// If there's a collision we'll append running number until there's no collision, e.g. 010101_1, 010101_2, ...
-			candidate = fmt.Sprintf("%s_%d", root, counter)
-			counter++
-		} else {
+		// If there's a collision we'll append running number until there's no collision, e.g. 010101_1, 010101_2, ...
+		candidate := fmt.Sprintf("%s_%d", root, counter)
+		if !ctrl.nameInUse(candidate) {
 			pee.NameRoot = candidate
 			return
 		}
+		counter++
 	}
 }
 


### PR DESCRIPTION
Fix the following issues:
- Add debug log for `CreateDirectory` thats to make deubgging the core easier
- fixed `EnsureNameRootSet ` and split logic to another function `generateName` which contains the logic to get name that is not used for specific `executionId`
- `EnsureNameRootSet` now saves the session to make sure that we don't have the issues with multiple users / groups trying to be created with the same `NameRoot`
- Because `EnsureNameRootSet` now saves the session before it contains the user information. When trying to `AcquirePrivateExecutionSession` we had an issue that there may be an execution that is not yet initialized fully, and may not contain the `User` on it (that may cause panic) so added retry for making sure it gets to initialized execution session
-  `createExecutionSession` now contains `defer` functions which recover if there is an issue with the creation